### PR TITLE
more readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,21 @@ Example:
 ```javascript
 fetch('https://test.cors.workers.dev/?https://httpbin.org/post', {
   method: 'post',
-  headers: { 'x-foo': 'bar', 'x-bar': 'foo', 'x-cors-headers': JSON.stringify({"additional_header": "value"}) }
-}).then(r => {console.log(JSON.parse(r.headers.get("cors-received-headers")));return r.json()}).then(console.log)
+  headers: {
+    'x-foo': 'bar',
+    'x-bar': 'foo',
+    'x-cors-headers': JSON.stringify({
+      // allows to send forbidden headers
+      // https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
+      'cookies': 'x=123'
+    }) 
+  }
+}).then(res => {
+  // allows to read all headers (even forbidden headers like set-cookies)
+  const headers = JSON.parse(res.headers.get('cors-received-headers'))
+  console.log(headers)
+  return res.json()
+}).then(console.log)
 ```
 
 Note:


### PR DESCRIPTION
also explains why x-cors-headers exist by referring to "forbidden headers" that also contains a list of the forbidden headers