### PR TITLE
Swap unescape for newer decodeURIComponent

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ addEventListener("fetch", async event=>{
             }
             return myHeaders;
         }
-        var fetch_url = unescape(unescape(origin_url.search.substr(1)));
+        var fetch_url = decodeURIComponent(decodeURIComponent(origin_url.search.substr(1)));
 
         var orig = event.request.headers.get("Origin");
         


### PR DESCRIPTION
Unescape can cause Â characters in URL's that are already encoded, I think it has something to do with non UTF characters? I am not sure why the double unescape exists, but this fixed my issue so I figured I would open a PR

`unescape(unescape("document/commercial%C2%A0irrigation-demand-worksheet%C2%A0%C2%A0-29816"))`

![image](https://user-images.githubusercontent.com/2799150/106799388-2f6a7700-662d-11eb-908d-8578bc31b31c.png)


