### PR TITLE
Fix "cannot assign responseHeaders" issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,6 @@ addEventListener("fetch", async event => {
 
                 headers.delete("X-Content-Type-Options"); // Remove X-Content-Type-Options header
             }
-            return headers;
         }
 
         const targetUrl = decodeURIComponent(decodeURIComponent(originUrl.search.substr(1)));
@@ -103,7 +102,7 @@ addEventListener("fetch", async event => {
                     allResponseHeaders[key] = value;
                 }
                 exposedHeaders.push("cors-received-headers");
-                responseHeaders = setupCORSHeaders(responseHeaders);
+                setupCORSHeaders(responseHeaders);
 
                 responseHeaders.set("Access-Control-Expose-Headers", exposedHeaders.join(","));
                 responseHeaders.set("cors-received-headers", JSON.stringify(allResponseHeaders));
@@ -119,7 +118,7 @@ addEventListener("fetch", async event => {
 
             } else {
                 const responseHeaders = new Headers();
-                responseHeaders = setupCORSHeaders(responseHeaders);
+                setupCORSHeaders(responseHeaders);
 
                 let country = false;
                 let colo = false;


### PR DESCRIPTION
What?

responseHeaders was declared a constant, reassigning it was causing causing problem
![image](https://github.com/user-attachments/assets/272377c8-57bb-42c6-bdde-7d0267878b0c)


How?
Fixed reassigning const variable issue by removing unnecessary reassignment as headers would automatically be updated inside headers