### PR TITLE
feat: Allow reassignment of responseHeaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ addEventListener("fetch", async event => {
                 });
 
                 const response = await fetch(targetUrl, newRequest);
-                const responseHeaders = new Headers(response.headers);
+                let responseHeaders = new Headers(response.headers);
                 const exposedHeaders = [];
                 const allResponseHeaders = {};
                 for (const [key, value] of response.headers.entries()) {
@@ -118,7 +118,7 @@ addEventListener("fetch", async event => {
                 return new Response(responseBody, responseInit);
 
             } else {
-                const responseHeaders = new Headers();
+                let responseHeaders = new Headers();
                 responseHeaders = setupCORSHeaders(responseHeaders);
 
                 let country = false;


### PR DESCRIPTION
The `responseHeaders` variable was initially declared as a `const`, but it was later reassigned, causing a build failure. This change updates the declaration to `let`, enabling the necessary reassignment and resolving the build error.